### PR TITLE
Added nonmerged PR links and unassigned issue links

### DIFF
--- a/pr_dump/vansh-codes.md
+++ b/pr_dump/vansh-codes.md
@@ -1,0 +1,12 @@
+## PR's not merged
+- https://github.com/PatilHarshh/Kaam-Do/pull/294
+- https://github.com/PatilHarshh/Kaam-Do/pull/363 (created recently because waiting for earlier PR to be merged)
+- https://github.com/adarsh-singh01/PrithWe/pull/165
+- https://github.com/adarsh-singh01/PrithWe/pull/203 (created recently because waiting for earlier PR to be merged becuase I didnt knew that we can create multiple PRs without conflicts)
+- https://github.com/Rakesh9100/CalcDiverse/pull/1829
+- https://github.com/Rakesh9100/CalcDiverse/pull/1840
+
+## Issues not assigned
+- https://github.com/SyedImtiyaz-1/GetTechProjects/issues/849
+- https://github.com/SyedImtiyaz-1/GetTechProjects/issues/850
+- https://github.com/SyedImtiyaz-1/GetTechProjects/issues/851


### PR DESCRIPTION
Added nonmerged PR links and unassigned issue links for GSSOC verification 

## PR's not merged
- https://github.com/PatilHarshh/Kaam-Do/pull/294
- https://github.com/PatilHarshh/Kaam-Do/pull/363 (created recently because waiting for earlier PR to be merged)
- https://github.com/adarsh-singh01/PrithWe/pull/165
- https://github.com/adarsh-singh01/PrithWe/pull/203 (created recently because waiting for earlier PR to be merged becuase I didnt knew that we can create multiple PRs without conflicts)
- https://github.com/Rakesh9100/CalcDiverse/pull/1829
- https://github.com/Rakesh9100/CalcDiverse/pull/1840

## Issues not assigned
- https://github.com/SyedImtiyaz-1/GetTechProjects/issues/849
- https://github.com/SyedImtiyaz-1/GetTechProjects/issues/850
- https://github.com/SyedImtiyaz-1/GetTechProjects/issues/851